### PR TITLE
Add tests move createCard method

### DIFF
--- a/src/Deck.js
+++ b/src/Deck.js
@@ -1,11 +1,23 @@
+const Card = require('./Card');
 class Deck {
-  constructor(cards) {
-    this.cards = cards || [];
-    // this.cardCount = cards ? this.cards.length : 0;
+  constructor(newCards) {
+    this.cards = this.createCards(newCards);
   }
+
   countCards = () => {
     return this.cards.length
   }
+
+  createCards = (cards) => {
+    if (cards) {
+      return cards.map(card => {
+        return card instanceof Card ? card 
+        : new Card(card.id, card.question, card.answers, card.correctAnswer)
+      });
+    } else {
+      return []
+    }
+  }  
 }
 
 module.exports = Deck;

--- a/src/Game.js
+++ b/src/Game.js
@@ -1,8 +1,6 @@
 const data = require('./data');
-// const prototypeQuestions = data.prototypeData;
 const util = require('./util');
 const Round = require('./Round');
-const Card = require('./Card');
 const Deck = require('./Deck');
 
 
@@ -19,16 +17,12 @@ class Game {
   }
 
   start = (cards) => {
-    const pile = [];
-    cards.forEach(card => pile.push(this.createCard(card)));   
-    this.newRound(pile);
+    this.newRound(cards);
     this.printMessage(this.deck);
     this.printQuestion(this.currentRound)
   }
   
-  createCard = (card) => {
-    return new Card(card.id, card.question, card.answers, card.correctAnswer); 
-  }
+
   
   newRound = (cards) =>  {
     this.deck = new Deck(cards); 

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -35,4 +35,12 @@ describe('Card', () => {
   it('should have an id', () => {
     expect(card.id).to.equal(1);
   });
+
+  it('should be able to store different, ids, questions and answers', () => {
+    const card2 = new Card(2, 'how\'s my hair today?', ['good', 'bad'], 'good');
+    expect(card2.id).to.equal(2);
+    expect(card2.question).to.equal('how\'s my hair today?');
+    expect(card2.answers).to.deep.equal(['good', 'bad']);
+    expect(card2.correctAnswer).to.equal('good');
+  })
 });

--- a/test/Deck-test.js
+++ b/test/Deck-test.js
@@ -52,4 +52,24 @@ describe('Deck', () => {
     const cardCount2 = deck2.countCards()
     expect(cardCount2).to.equal(3);
   });
+
+  it('can create Card objects from objects not defined with the card class', () => {
+  const pile = [{
+    id: 1,
+    question: "How do you fly?",
+    answers: ["you don't", "you flap your arms", "you steal an airplane"],
+    correctAnswer: "you don't"
+    }, {
+    id: 2,
+    question: "Can I eat a hotdog?",
+    answers: ["Yes", "No", "You can eat several"],
+    correctAnswer: "You can eat several"
+    }];
+  
+  const deck = new Deck(pile);
+  expect(deck.cards[0]).to.deep.equal(cards[0]);
+  expect(deck.cards[0]).to.be.an.instanceOf(Card);
+  expect(deck.cards[1]).to.deep.equal(cards[1]);
+  expect(deck.cards[1]).to.be.an.instanceOf(Card);
+  });
 });

--- a/test/Game-test.js
+++ b/test/Game-test.js
@@ -30,10 +30,6 @@ describe.skip('Game', ()=> {
   });
 
   describe('Start Method', () => {
-    it('should create cards', () => {
-      game.start(cards);
-      expect(game.deck.cards[0]).to.be.an.instanceOf(Card);
-    });
 
     it('should put cards in a deck', () => {
       game.start(cards);


### PR DESCRIPTION
###### What's this PR do?
* Adds a few additional tests
* Attempted to do some "sad path" testing but ran into enough problems that it didn't seem worth it given the amount of time left
* Moved `createCards` method from `Game` to `Deck`. Previously it was part of the start function, which decreased SRP. As a method of a Deck `createCards can be used to automatically transform any array of Cards into an array of Card objects. If the Deck is created with Card objects from the outset it still passes tests.
###### How should this be manually tested?
More testing is desired to prevent the deck from crashing when presented with other data types and objects which don't contain the expected key/value pairs.